### PR TITLE
lists from localStorage and add clearAction for settings

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,9 +5,13 @@ import { bindActionCreators } from 'redux';
 
 import Router from './containers/Router';
 import { fetchFilms } from './store/actions/getApiAction';
+import { getFromLocalStorage } from './store/actions/getFromLocalStorage';
 
-const App = ({ fetchFilms }) => {
+const App = ({ fetchFilms, getFromLocalStorage }) => {
   useEffect(() => {
+    console.log(localStorage.getItem('blacklist'));
+    console.log(localStorage.getItem('seenList'));
+    getFromLocalStorage();
     fetchFilms();
   });
 
@@ -19,9 +23,10 @@ const App = ({ fetchFilms }) => {
 };
 
 App.propTypes = {
-  fetchFilms: PropTypes.func
+  fetchFilms: PropTypes.func,
+  getFromLocalStorage: PropTypes.func
 };
 
-const mapDispatchToProps = dispatch => bindActionCreators({ fetchFilms }, dispatch);
+const mapDispatchToProps = dispatch => bindActionCreators({ fetchFilms, getFromLocalStorage }, dispatch);
 
 export default connect(null, mapDispatchToProps)(App);

--- a/frontend/src/containers/FilmCardContainer.jsx
+++ b/frontend/src/containers/FilmCardContainer.jsx
@@ -8,20 +8,22 @@ import FilmCard from '../pages/FilmCard';
 import { addToBlacklistFilms, addToAlreadySeenFilms } from '../store/actions/filmActions';
 import { changeFilm } from '../store/actions/changeFilmAction';
 
-const FilmCardContainer = ({ film, addToBlacklistFilms, addToAlreadySeenFilms, changeFilm, error }) => {
+const FilmCardContainer = ({ film, alreadySeenFilms, blacklistFilms, addToBlacklistFilms, addToAlreadySeenFilms, changeFilm, error }) => {
     const handleChangeFilm = useCallback(() => {
         changeFilm();
     }, [changeFilm]);
 
     const handleRemoveFilmToBlacklist = useCallback(() => {
         addToBlacklistFilms(film.id);
+        localStorage.setItem('blacklist', JSON.stringify(blacklistFilms));
         handleChangeFilm();
-    }, [film, addToBlacklistFilms, handleChangeFilm]);
+    }, [film, blacklistFilms, addToBlacklistFilms, handleChangeFilm]);
 
     const handleRemoveFilmToAlreadySeen = useCallback(() => {
         addToAlreadySeenFilms(film.id);
+        localStorage.setItem('seenList', JSON.stringify(alreadySeenFilms));
         handleChangeFilm();
-    }, [film, addToAlreadySeenFilms, handleChangeFilm]);
+    }, [film, alreadySeenFilms, addToAlreadySeenFilms, handleChangeFilm]);
 
     return (
         !film ? <Spinner /> : <FilmCard error={error} film={film} changeFilm={handleChangeFilm} removeFilm={handleRemoveFilmToBlacklist} seenFilm={handleRemoveFilmToAlreadySeen} />
@@ -31,6 +33,8 @@ const FilmCardContainer = ({ film, addToBlacklistFilms, addToAlreadySeenFilms, c
 FilmCardContainer.propTypes = {
     error: PropTypes.string,
     film: PropTypes.object,
+    blacklistFilms: PropTypes.object,
+    alreadySeenFilms: PropTypes.object,
     addToBlacklistFilms: PropTypes.func,
     addToAlreadySeenFilms: PropTypes.func,
     changeFilm: PropTypes.func
@@ -38,7 +42,9 @@ FilmCardContainer.propTypes = {
 
 const mapStateToProps = ({ filmReducer }) => ({
     error: filmReducer.error,
-    film: filmReducer.film
+    film: filmReducer.film,
+    blacklistFilms: filmReducer.blacklistFilms,
+    alreadySeenFilms: filmReducer.alreadySeenFilms
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({ changeFilm, addToBlacklistFilms, addToAlreadySeenFilms }, dispatch);

--- a/frontend/src/containers/FilmCardContainer.jsx
+++ b/frontend/src/containers/FilmCardContainer.jsx
@@ -13,20 +13,20 @@ const FilmCardContainer = ({ film, alreadySeenFilms, blacklistFilms, addToBlackl
         changeFilm();
     }, [changeFilm]);
 
-    const handleRemoveFilmToBlacklist = useCallback(() => {
+    const handleMoveFilmToBlacklist = useCallback(() => {
         addToBlacklistFilms(film.id);
         localStorage.setItem('blacklist', JSON.stringify(blacklistFilms));
         handleChangeFilm();
     }, [film, blacklistFilms, addToBlacklistFilms, handleChangeFilm]);
 
-    const handleRemoveFilmToAlreadySeen = useCallback(() => {
+    const handleMoveFilmToAlreadySeen = useCallback(() => {
         addToAlreadySeenFilms(film.id);
         localStorage.setItem('seenList', JSON.stringify(alreadySeenFilms));
         handleChangeFilm();
     }, [film, alreadySeenFilms, addToAlreadySeenFilms, handleChangeFilm]);
 
     return (
-        !film ? <Spinner /> : <FilmCard error={error} film={film} changeFilm={handleChangeFilm} removeFilm={handleRemoveFilmToBlacklist} seenFilm={handleRemoveFilmToAlreadySeen} />
+        !film ? <Spinner /> : <FilmCard error={error} film={film} changeFilm={handleChangeFilm} removeFilm={handleMoveFilmToBlacklist} seenFilm={handleMoveFilmToAlreadySeen} />
     )
 };
 

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -3,20 +3,17 @@ import ReactDOM from "react-dom";
 import "antd/dist/antd.css";
 import { ConnectedRouter } from "connected-react-router";
 import { Provider } from "react-redux";
-import { PersistGate } from "redux-persist/integration/react";
 import reportWebVitals from "./reportWebVitals";
 import "./styles/styles.scss";
 
 import App from "./App";
-import { store, persistor, history } from "./store";
+import { store, history } from "./store";
 
 ReactDOM.render(
   <Provider store={store}>
-    <PersistGate loading={null} persistor={persistor}>
       <ConnectedRouter history={history}>
         <App />
       </ConnectedRouter>
-    </PersistGate>
   </Provider>,
   document.getElementById("root")
 );

--- a/frontend/src/pages/FilmCard/FilmCard.jsx
+++ b/frontend/src/pages/FilmCard/FilmCard.jsx
@@ -75,8 +75,8 @@ const FilmCard = ({ film, changeFilm, seenFilm, removeFilm, error }) => {
             </div>
             <div className="filmCard__footer theme">
                 <div className="filmCard__footer__buttonGroup">
-                    <FilmCardButton eventAction={ removeFilm }>уже смотрел</FilmCardButton>
-                    <FilmCardButton eventAction={ seenFilm }>не предлагать</FilmCardButton>
+                    <FilmCardButton eventAction={ seenFilm }>уже смотрел</FilmCardButton>
+                    <FilmCardButton eventAction={ removeFilm }>не предлагать</FilmCardButton>
                     <FilmCardButton eventAction={ changeFilm }>в другой раз</FilmCardButton>
                 </div>
                 <div className="filmCard__footer__emptyBlock" ref={ cardEndRef }></div>

--- a/frontend/src/pages/Settings/Settings.jsx
+++ b/frontend/src/pages/Settings/Settings.jsx
@@ -1,4 +1,10 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import connect from 'react-redux/es/connect/connect';
+import { bindActionCreators } from 'redux';
+
+import { clearLists } from '../../store/actions/filmActions';
+
 import { Typography, Button, Slider, Select } from 'antd';
 import Navigation from '../../components/Navigation';
 import { RATINGS, YEARS, GENRES, COUNTRIES } from './config';
@@ -24,6 +30,12 @@ const Settings = (props) => {
         if (value === "Все") {
             (type === "genres") ? setSelectedGenres([]) : setSelectedCountries([])
         }
+    }
+
+    const handleClearSettings = () => {
+        props.clearLists();
+        localStorage.removeItem('blacklist');
+        localStorage.removeItem('seenList');
     }
 
     return (
@@ -85,7 +97,7 @@ const Settings = (props) => {
                     />
                 </div>
 
-                <Button type="secondary" size="large" className="settings__content--reset">
+                <Button type="secondary" size="large" className="settings__content--reset" onClick={handleClearSettings}>
                     Сбросить настройки
                 </Button>
 
@@ -95,4 +107,10 @@ const Settings = (props) => {
     )
 };
 
-export default Settings;
+Settings.propTypes = {
+    clearLists: PropTypes.func
+};
+
+const mapDispatchToProps = dispatch => bindActionCreators({ clearLists }, dispatch);
+
+export default connect(null, mapDispatchToProps)(Settings);

--- a/frontend/src/store/actions/filmActions.js
+++ b/frontend/src/store/actions/filmActions.js
@@ -4,6 +4,9 @@ export const LOAD_FILMS_FAILURE = '@@film/LOAD_FILMS_FAILURE';
 export const ADD_TO_BLACKLIST_FILMS = '@@film/ADD_TO_BLACKLIST_FILMS';
 export const ADD_TO_ALREADY_SEEN_FILMS = '@@film/ADD_TO_ALREADY_SEEN_FILMS';
 export const GET_RANDOM_FILM = '@@film/GET_RANDOM_FILM';
+export const GET_BLACKLIST_FROM_LOCAL_STORAGE = '@@film/GET_BLACKLIST_FROM_LOCAL_STORAGE';
+export const GET_SEENLIST_FROM_LOCAL_STORAGE = '@@film/GET_SEENLIST_FROM_LOCAL_STORAGE';
+export const CLEAR_LISTS = '@@film/CLEAR_LISTS';
 
 export const loadFilms = (films) => ({
     type: LOAD_FILMS,
@@ -32,4 +35,18 @@ export const addToBlacklistFilms = (filmId) => ({
 export const addToAlreadySeenFilms = (filmId) => ({
     type: ADD_TO_ALREADY_SEEN_FILMS,
     filmId
+});
+
+export const getBlacklistFromLocalStorage = (blacklist) => ({
+    type: GET_BLACKLIST_FROM_LOCAL_STORAGE,
+    blacklist
+});
+
+export const getSeenListFromLocalStorage = (seenList) => ({
+    type: GET_SEENLIST_FROM_LOCAL_STORAGE,
+    seenList
+});
+
+export const clearLists = () => ({
+    type: CLEAR_LISTS
 });

--- a/frontend/src/store/actions/getFromLocalStorage.js
+++ b/frontend/src/store/actions/getFromLocalStorage.js
@@ -1,0 +1,16 @@
+import { getBlacklistFromLocalStorage, getSeenListFromLocalStorage } from './filmActions';
+
+export const getFromLocalStorage = () => {
+    return dispatch => {
+        if (localStorage.blacklist) {
+            dispatch(getBlacklistFromLocalStorage(JSON.parse(localStorage.blacklist)));
+        } else {
+            dispatch(getBlacklistFromLocalStorage({ data: [], list: {} }));
+        }
+        if (localStorage.seenList) {
+            dispatch(getSeenListFromLocalStorage(JSON.parse(localStorage.seenList)));
+        } else {
+            dispatch(getSeenListFromLocalStorage({ data: [], list: {} }));
+        }
+    }
+};

--- a/frontend/src/store/actions/getFromLocalStorage.js
+++ b/frontend/src/store/actions/getFromLocalStorage.js
@@ -4,13 +4,9 @@ export const getFromLocalStorage = () => {
     return dispatch => {
         if (localStorage.blacklist) {
             dispatch(getBlacklistFromLocalStorage(JSON.parse(localStorage.blacklist)));
-        } else {
-            dispatch(getBlacklistFromLocalStorage({ data: [], list: {} }));
         }
         if (localStorage.seenList) {
             dispatch(getSeenListFromLocalStorage(JSON.parse(localStorage.seenList)));
-        } else {
-            dispatch(getSeenListFromLocalStorage({ data: [], list: {} }));
         }
     }
 };

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1,22 +1,12 @@
 import { createStore, applyMiddleware, compose } from 'redux';
 import { createBrowserHistory } from 'history';
 import { routerMiddleware } from 'connected-react-router';
-import { persistStore, persistReducer } from 'redux-persist';
-import storage from 'redux-persist/lib/storage';
-import autoMergeLevel2 from 'redux-persist/lib/stateReconciler/autoMergeLevel2';
 import thunk from 'redux-thunk';
 
 import RootReducers from './reducers';
 import middlewares from './middlewares';
 
 export const history = createBrowserHistory();
-
-const persistConfig = {
-    key: 'filmSearch',
-    storage,
-    stateReconciler: autoMergeLevel2,
-    whitelist: ['filmReducer'],
-};
 
 // тернарник внутри compose не сработает
 const composer = window.__REDUX_DEVTOOLS_EXTENSION__ ? compose(
@@ -27,8 +17,6 @@ const composer = window.__REDUX_DEVTOOLS_EXTENSION__ ? compose(
 );
 
 export const store = createStore(
-    persistReducer(persistConfig, RootReducers(history)),
+    RootReducers(history),
     composer,
 );
-
-export const persistor = persistStore(store);

--- a/frontend/src/store/reducers/filmReducer.js
+++ b/frontend/src/store/reducers/filmReducer.js
@@ -1,17 +1,11 @@
 import update from 'react-addons-update';
-import { ADD_TO_ALREADY_SEEN_FILMS, ADD_TO_BLACKLIST_FILMS, LOAD_FILMS, GET_RANDOM_FILM, LOAD_FILMS_STARTED, LOAD_FILMS_FAILURE } from '../actions/filmActions';
+import { ADD_TO_ALREADY_SEEN_FILMS, ADD_TO_BLACKLIST_FILMS, LOAD_FILMS, GET_RANDOM_FILM, LOAD_FILMS_STARTED, LOAD_FILMS_FAILURE, GET_BLACKLIST_FROM_LOCAL_STORAGE, GET_SEENLIST_FROM_LOCAL_STORAGE, CLEAR_LISTS } from '../actions/filmActions';
 
 const initStore = {
     films: [],
     film: null,
-    blacklistFilms: {
-        data: [],
-        list: {}
-    },
-    alreadySeenFilms: {
-        data: [],
-        list: {}
-    },
+    blacklistFilms: {},
+    alreadySeenFilms: {},
     nextTime: {
         data: {},
         list: {}
@@ -46,6 +40,20 @@ export default function filmReducer(store = initStore, action) {
                 },
                 error: {
                     $set: null
+                }
+            });
+        }
+        case GET_BLACKLIST_FROM_LOCAL_STORAGE: {
+            return update(store, {
+                blacklistFilms: {
+                    $set: {...action.blacklist}
+                }
+            });
+        }
+        case GET_SEENLIST_FROM_LOCAL_STORAGE: {
+            return update(store, {
+                alreadySeenFilms: {
+                    $set: {...action.seenList}
                 }
             });
         }
@@ -100,6 +108,22 @@ export default function filmReducer(store = initStore, action) {
                             ...store.alreadySeenFilms.list,
                             [action.filmId]: true
                         }
+                    }
+                }
+            });
+        }
+        case CLEAR_LISTS: {
+            return update(store, {
+                alreadySeenFilms: {
+                    $set: {
+                        data: [],
+                        list: {}
+                    }
+                },
+                blacklistFilms: {
+                    $set: {
+                        data: [],
+                        list: {}
                     }
                 }
             });

--- a/frontend/src/store/reducers/filmReducer.js
+++ b/frontend/src/store/reducers/filmReducer.js
@@ -4,12 +4,9 @@ import { ADD_TO_ALREADY_SEEN_FILMS, ADD_TO_BLACKLIST_FILMS, LOAD_FILMS, GET_RAND
 const initStore = {
     films: [],
     film: null,
-    blacklistFilms: {},
-    alreadySeenFilms: {},
-    nextTime: {
-        data: {},
-        list: {}
-    },
+    blacklistFilms: { data: [], list: {} },
+    alreadySeenFilms: { data: [], list: {} },
+    nextTime: { data: [], list: {} },
     isLoading: false,
     error: null
 }
@@ -46,14 +43,14 @@ export default function filmReducer(store = initStore, action) {
         case GET_BLACKLIST_FROM_LOCAL_STORAGE: {
             return update(store, {
                 blacklistFilms: {
-                    $set: {...action.blacklist}
+                    $set: { ...action.blacklist }
                 }
             });
         }
         case GET_SEENLIST_FROM_LOCAL_STORAGE: {
             return update(store, {
                 alreadySeenFilms: {
-                    $set: {...action.seenList}
+                    $set: { ...action.seenList }
                 }
             });
         }


### PR DESCRIPTION
1) Обновил компонент Settings, добавил в него метод handleClearSettings, который зачищает пока что только состояние списков (blacklistFilms и alreadySeenFilms в store + local storage), а также подключил к компоненту store.
В последствии можно повесить на данный экшен сброс других настроек, когда они будут перенесены в store.

Сам компонент теперь является контейнером, поэтому нужно всю верстку убрать в отдельный компонент-отрисовщик, а также не забыть передать в него все пропсы, которыми аппелирует верстка.

2) При загрузке приложения, помимо подтягивания фильмов из JSON, подтягивается состояние списков (просмотренные, черный список) из local storage.

3) Убрал persist из приложения.

Еще буду дорабатывать корректную запись состояния списков в local storage, сейчас данные записываются, но не совсем так, как нужно.